### PR TITLE
Fixed broken GALX regex

### DIFF
--- a/pytrends/pyGTrends.py
+++ b/pytrends/pyGTrends.py
@@ -64,7 +64,11 @@ class pyGTrends(object):
         galx = re.compile('<input name="GALX"[\s]+type="hidden"[\s]+value="(?P<galx>[a-zA-Z0-9_-]+)">')
         m = galx.search(resp)
         if not m:
-            raise Exception('Cannot parse GALX out of login page')
+            galx = re.compile('<input type="hidden"[\s]+name="GALX"[\s]+value="(?P<galx>[a-zA-Z0-9_-]+)">')
+            m = galx.search(resp)
+            if not m:
+                raise Exception('Cannot parse GALX out of login page')
+
         self.login_params['GALX'] = m.group('galx')
         params = urlencode(self.login_params).encode('utf-8')
         self.opener.open(self.url_ServiceLoginBoxAuth, params)


### PR DESCRIPTION
If the original regex fails to find the GALX value it will try my slightly modified regex, if that also fails it will throw the error. Used to fix a small change in the google login page. 